### PR TITLE
Instead of hardcoding the path `../rust`, calculate relative directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clean-path"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaa6b4b263a5d737e9bf6b7c09b72c41a5480aec4d7219af827f6564e950b6a5"
+
+[[package]]
 name = "cliclack"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +130,7 @@ dependencies = [
 name = "scaffold-godot-rust"
 version = "0.1.5"
 dependencies = [
+ "clean-path",
  "cliclack",
  "colored",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "scaffold-godot-rust"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "clean-path",
  "cliclack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scaffold-godot-rust"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["ByteAtATime <byteatatime@proton.me>"]
 description = "A simple scaffold for Godot Rust projects"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ edition = "2021"
 [dependencies]
 colored = "2.1.0"
 cliclack = "0.1.10"
+clean-path = "0.2.1"

--- a/src/generate_files.rs
+++ b/src/generate_files.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 pub fn generate_godot_project_file(project_name: &str) -> String {
     format!(
         r#"; Engine configuration file.
@@ -24,21 +26,22 @@ renderer/rendering_method.mobile="gl_compatibility""#,
     )
 }
 
-pub fn generate_gdextention_file(project_name: &str, reloadable: bool) -> String {
+pub fn generate_gdextention_file(project_name: &str, reloadable: bool, backtrack_count: usize, rust_dir: &PathBuf) -> String {
+    let rust_path = std::iter::repeat("../").take(backtrack_count as usize).collect::<String>() + rust_dir.to_str().unwrap();
     format!(
         r#"[configuration]
 entry_symbol = "gdext_rust_init"
 compatibility_minimum = 4.1
 {reloadable}
 [libraries]
-linux.debug.x86_64 =     "res://../rust/target/debug/lib{YourCrate}.so"
-linux.release.x86_64 =   "res://../rust/target/release/lib{YourCrate}.so"
-windows.debug.x86_64 =   "res://../rust/target/debug/{YourCrate}.dll"
-windows.release.x86_64 = "res://../rust/target/release/{YourCrate}.dll"
-macos.debug =            "res://../rust/target/debug/lib{YourCrate}.dylib"
-macos.release =          "res://../rust/target/release/lib{YourCrate}.dylib"
-macos.debug.arm64 =      "res://../rust/target/debug/lib{YourCrate}.dylib"
-macos.release.arm64 =    "res://../rust/target/release/lib{YourCrate}.dylib""#,
+linux.debug.x86_64 =     "res://{rust_path}/target/debug/lib{YourCrate}.so"
+linux.release.x86_64 =   "res://{rust_path}/target/release/lib{YourCrate}.so"
+windows.debug.x86_64 =   "res://{rust_path}/target/debug/{YourCrate}.dll"
+windows.release.x86_64 = "res://{rust_path}/target/release/{YourCrate}.dll"
+macos.debug =            "res://{rust_path}/target/debug/lib{YourCrate}.dylib"
+macos.release =          "res://{rust_path}/target/release/lib{YourCrate}.dylib"
+macos.debug.arm64 =      "res://{rust_path}/target/debug/lib{YourCrate}.dylib"
+macos.release.arm64 =    "res://{rust_path}/target/release/lib{YourCrate}.dylib""#,
         reloadable = if reloadable {
             "reloadable = true\n"
         } else {
@@ -65,7 +68,7 @@ godot = {{ git = "https://github.com/godot-rust/gdext", branch = "master" }}
     )
 }
 
-pub fn generate_launch_config(godot_dir: &str, godot_location: &str) -> String {
+pub fn generate_launch_config(godot_dir: &PathBuf, godot_location: &str) -> String {
     format!(
         r#"{{
     "configurations": [
@@ -83,7 +86,7 @@ pub fn generate_launch_config(godot_dir: &str, godot_location: &str) -> String {
         }}
     ]
 }}"#,
-        godot_dir, godot_location
+        godot_dir.to_str().unwrap(), godot_location
     )
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod generate_files;
 
+use clean_path::Clean;
 use generate_files::*;
 
 use std::{io::Error, path::PathBuf};
@@ -22,6 +23,7 @@ fn main() -> Result<(), Error> {
     let dir: PathBuf = input("Project Directory (leave empty for current folder): ")
         .default_input(".")
         .interact()?;
+    let dir = dir.clean();
 
     log::info("[Godot]".underline().bold())?;
 
@@ -61,8 +63,8 @@ fn main() -> Result<(), Error> {
             .required(false)
             .interact()?;
 
-    let godot_full_path = dir.join(&godot_dir_name);
-    let rust_full_path = dir.join(&rust_dir_name);
+    let godot_full_path = dir.join(&godot_dir_name).clean();
+    let rust_full_path = dir.join(&rust_dir_name).clean();
 
     create_godot_project(
         godot_full_path.clone(),


### PR DESCRIPTION
This is implemented in a very naïve way, by backtracking to the root of the project then appending the Rust project path. I believe there are much better ways of doing this, which I will look into at a future date.